### PR TITLE
VIsual enhancements for mobile experience

### DIFF
--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -81,7 +81,7 @@ h1 {
   padding-right: 0;
   padding-top: 0;
   text-align: center;
-  margin-bottom: .75em;
+  margin-bottom: .5em;
   color: inherit;
   font-family: 'League Spartan', -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
@@ -124,13 +124,4 @@ p *:last-child {
   html {
     font-size: 100%;
   }
-  h1 {
-    font-size: 5em;
-    line-height: 1.1em;
-    margin-bottom: 0.5em
-  }
-  p {
-    font-size: 2em;
-    line-height: 1.5em;
-  };
 }

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -10,7 +10,7 @@ const TemplateWrapper = ({ children }) => (
     <Helmet
       title="Marcel Cutts"
       meta={[
-        { name: 'description', content: "Marcel Cutts's personal site" },
+        { name: 'description', content: "Marcel Cutts' personal site" },
         {
           name: 'keywords',
           content: 'Personal site, work, history, programming, engineering',
@@ -21,9 +21,9 @@ const TemplateWrapper = ({ children }) => (
       style={{
         margin: '0 auto',
         maxWidth: 960,
-        padding: '0px 1.0875rem 1.45rem',
+        padding: '0px 1.0875rem 0px',
         paddingTop: 0,
-        height: '100vh',
+        'min-height': '100vh',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -1,0 +1,21 @@
+hr {
+  display: none;
+  width: 60%;
+}
+
+@media only screen and (max-width: 480px) {
+  hr {
+    display: block;
+  }
+  .index h1 {
+    margin-bottom: 2rem;
+    font-size: 5em;
+    line-height: 1.1em;
+  }
+  .index p {
+    margin-top: 2rem;
+    font-size: 2.5em;
+    line-height: 1.2em;
+    margin-bottom: 0;
+  }
+} 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,12 @@
 import React from 'react'
 import Link from 'gatsby-link'
 
+import "./index.css";
+
 const IndexPage = () => (
-  <div>
+  <div className="index">
     <h1>Marcel Cutts</h1>
+    <hr />
     <p>Technologist with a relentless vendetta against mediocrity.</p>
   </div>
 )


### PR DESCRIPTION
Text only sites are harder in a less conventional format.

- Added a horizontal rule to separate motto from title
- Refined line height and font size to be more distinct and legible

These sizes were eyeballed rather than through a use of ratios. Typographic guides don't seem to work quite right for small character-per-line environments. 