### PR TITLE
Mobile content snapping to top

### DIFF
--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -120,8 +120,25 @@ strong {
 p *:last-child {
   margin-bottom: 0;
 }
+
+.template {
+  margin: 0 auto;
+  max-width: 960;
+  padding: 0px 1.0875rem 0px;
+  padding-top: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 @media only screen and (max-width: 480px) {
   html {
     font-size: 100%;
+  } 
+
+  .template {
+    align-items: flex-start;
+    padding-top: 2rem;
   }
 }

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -17,18 +17,7 @@ const TemplateWrapper = ({ children }) => (
         },
       ]}
     />
-    <div
-      style={{
-        margin: '0 auto',
-        maxWidth: 960,
-        padding: '0px 1.0875rem 0px',
-        paddingTop: 0,
-        'min-height': '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
+    <div className="template">
       {children()}
     </div>
   </div>


### PR DESCRIPTION
Horizontally centring content is tricky on mobile browsers as the bars are temperamental and cover some viewport. 

So instead, on mobile devices we'll snap to top.